### PR TITLE
Fixed main-kts missing repository bintray

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 
 plugins {
-    kotlin("jvm") version "1.6.0"
+    kotlin("jvm") version "1.6.20"
 }
 
-val kotlinVersion: String by extra("1.6.0")
-val kotlinCoroutinesVersion: String by extra("1.6.0-RC")
+val kotlinVersion: String by extra("1.6.20")
+val kotlinCoroutinesVersion: String by extra("1.6.1")
 
 allprojects {
     repositories {

--- a/jvm/main-kts/scripts/kotlin-shell.main.kts
+++ b/jvm/main-kts/scripts/kotlin-shell.main.kts
@@ -1,6 +1,5 @@
 #!/usr/bin/env kotlin
 
-@file:Repository("https://dl.bintray.com/jakubriegel/kotlin-shell")
 @file:DependsOn("eu.jrie.jetbrains:kotlin-shell-core:0.2.1")
 @file:DependsOn("org.slf4j:slf4j-simple:1.7.28")
 @file:CompilerOptions("-Xopt-in=kotlin.RequiresOptIn")

--- a/jvm/main-kts/scripts/kotlin-shell.main.kts
+++ b/jvm/main-kts/scripts/kotlin-shell.main.kts
@@ -9,7 +9,9 @@ import eu.jrie.jetbrains.kotlinshell.shell.*
 
 shell {
     if (args.isEmpty()) {
-        "ls -l"()
+        val isWindows = System.getProperty("os.name").lowercase().contains("win")
+        if (isWindows) "cmd /c dir"()
+        else "ls -l"()
     } else {
         var lines = 0
         var words = 0

--- a/jvm/main-kts/scripts/kotlinx-html.main.kts
+++ b/jvm/main-kts/scripts/kotlinx-html.main.kts
@@ -1,7 +1,7 @@
 #!/usr/bin/env kotlin
 
-@file:Repository("https://jcenter.bintray.com")
-@file:DependsOn("org.jetbrains.kotlinx:kotlinx-html-jvm:0.6.11")
+// @file:Repository("https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven") // not needed
+@file:DependsOn("org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.5")
 
 import kotlinx.html.*; import kotlinx.html.stream.*; import kotlinx.html.attributes.*
 

--- a/jvm/simple-main-kts/simple-main-kts-test/testData/kotlinx-html.smain.kts
+++ b/jvm/simple-main-kts/simple-main-kts-test/testData/kotlinx-html.smain.kts
@@ -1,7 +1,7 @@
 #!/usr/bin/env kotlinc -cp dist/kotlinc/lib/kotlin-main-kts.jar -script
 
-@file:Repository("https://jcenter.bintray.com")
-@file:DependsOn("org.jetbrains.kotlinx:kotlinx-html-jvm:0.6.11")
+// @file:Repository("https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven") // not needed
+@file:DependsOn("org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.5")
 
 import kotlinx.html.*; import kotlinx.html.stream.*; import kotlinx.html.attributes.*
 


### PR DESCRIPTION
Fixed the files which failed to due to dead bintray. 

Ran the tests, and upgraded to available kotlinx.html.

Upgraded to kotlin 1.6.20 and the matching coroutines 1.6.1 because its available and still worked.

Updated a sample shell-file so it doesn't fail nearly as terrible on windows without arguments, though it still fails horribly with arguments