### PR TITLE
Demonstrate regression introduced in Kotlin Compiler v1.6.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     kotlin("jvm") version "1.6.0"
 }
 
-val kotlinVersion: String by extra("1.6.0")
+val kotlinVersion: String by extra("1.6.20")
 val kotlinCoroutinesVersion: String by extra("1.6.0-RC")
 
 allprojects {

--- a/jvm/simple-main-kts/simple-main-kts-test/testData/kotlinx-html.smain.kts
+++ b/jvm/simple-main-kts/simple-main-kts-test/testData/kotlinx-html.smain.kts
@@ -5,6 +5,19 @@
 
 import kotlinx.html.*; import kotlinx.html.stream.*; import kotlinx.html.attributes.*
 
+// Assigning `this` to a variable breaks compiler (v1.6.20, v1.6.21, v1.7.0, v1.7.10):
+//
+// File being compiled: testData/kotlinx-html.smain.kts
+// The root cause java.lang.IllegalStateException was thrown at: org.jetbrains.kotlin.ir.types.IrTypeUtilsKt.isNullable(IrTypeUtils.kt:41): org.jetbrains.kotlin.backend.common.BackendException: Backend Internal error: Exception during IR lowering
+//
+// It worked fine in v1.6.10.
+//
+// Note, that if the type is specified explicitly, i.e. `val self: org.jetbrains.kotlin.script.examples.simpleMainKts.SimpleMainKtsScript = this`, then it compiles fine.
+//
+// To reproduce:
+// ./gradlew :jvm:simple-main-kts:simple-main-kts-test:clean :jvm:simple-main-kts:simple-main-kts-test:test --tests org.jetbrains.kotlin.script.examples.simpleMainKts.test.SimpleMainKtsTest.testKotlinxHtml
+val self = this
+
 print(createHTML().html {
     body {
         h1 { +"Hello, World!" }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-53221/Scripts-Backend-Internal-error-Exception-during-IR-lowering-when-assigning-this-to-a-variable